### PR TITLE
Double click favorite file changes view

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1292,14 +1292,15 @@ void FileSystemDock::_tree_activate_file() {
 		TreeItem *parent = selected->get_parent();
 		bool is_favorite = parent != nullptr && parent->get_metadata(0) == "Favorites";
 
-		if ((!is_favorite && file_path.ends_with("/")) || file_path == "Favorites") {
+		if ((!is_favorite && file_path.ends_with("/")) || (file_path == "Favorites" && file_path.ends_with("/"))) {
 			bool collapsed = selected->is_collapsed();
 			selected->set_collapsed(!collapsed);
-		}else if(is_favorite && file_path.ends_with("/")) {
+		}
+		if(is_favorite && file_path.ends_with("/")) {
 			_navigate_to_path(file_path, true);
 		}
 		else if(is_favorite && !file_path.ends_with("/")){
-			_select_file(file_path, true, false);
+			_select_file(file_path, true, true);
 		}
 		 else {
 			_select_file(file_path, is_favorite && !file_path.ends_with("/"), false);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1291,13 +1291,18 @@ void FileSystemDock::_tree_activate_file() {
 		String file_path = selected->get_metadata(0);
 		TreeItem *parent = selected->get_parent();
 		bool is_favorite = parent != nullptr && parent->get_metadata(0) == "Favorites";
-		bool is_folder = file_path.ends_with("/");
 
-		if ((!is_favorite && is_folder) || file_path == "Favorites") {
+		if ((!is_favorite && file_path.ends_with("/")) || file_path == "Favorites") {
 			bool collapsed = selected->is_collapsed();
 			selected->set_collapsed(!collapsed);
-		} else {
-			_select_file(file_path, is_favorite && !is_folder, is_favorite && is_folder);
+		}else if(is_favorite && file_path.ends_with("/")) {
+			_navigate_to_path(file_path, true);
+		}
+		else if(is_favorite && !file_path.ends_with("/")){
+			_select_file(file_path, true, false);
+		}
+		 else {
+			_select_file(file_path, is_favorite && !file_path.ends_with("/"), false);
 		}
 	}
 }


### PR DESCRIPTION
Adjusts the functionality of the "favorite" tag in file system.

Changes
- When double clicking a file under the favorites tab in the file explorer, the users view will be moved to the actual location of the 
file in the directory.
- If a directory is click then the users view will be redirected to the directories actual location as well.
- Functionality of surrounding system remains untouched.